### PR TITLE
Update organization references in documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN chmod 755 /usr/local/lib/python${OPENCADC_PYTHON_VERSION}/site-packages/foot
 WORKDIR /usr/src/app
 
 ARG OPENCADC_BRANCH=main
-ARG OPENCADC_REPO=opencadc
+ARG OPENCADC_REPO=opencadc-metadata-curation
 
 RUN git clone https://github.com/${OPENCADC_REPO}/caom2tools.git && \
     cd caom2tools && \

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ docker-entrypoint.sh, and config.yml. Copy these files to the working directory.
 1. config.yml is configuration information for the ingestion. It will work with
 the files named and described here. For a complete description of its
 content, see
-https://github.com/opencadc/collection2caom2/wiki/config.yml.
+https://github.com/opencadc-metadata-curation/collection2caom2/wiki/config.yml.
 
 1. In this directory, create a file name netrc. This is the expected
 .netrc file that will have the credentials required for the caom2repo and
@@ -81,4 +81,4 @@ from data. This file should have content that looks like the following:
    ```
 
 1. For some instructions that might be helpful on using containers, see:
-https://github.com/opencadc/collection2caom2/wiki/Docker-and-Collections
+https://github.com/opencadc-metadata-curation/collection2caom2/wiki/Docker-and-Collections

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ author_email = cadc@nrc-cnrc.gc.ca
 license = AGPLv3
 url = TBD
 edit_on_github = False
-github_project = opencadc/omm2caom2
+github_project = opencadc-metadata-curation/omm2caom2
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 version = 0.13.4
 install_requires =


### PR DESCRIPTION
Update GitHub URLs in documentation from `opencadc` to `opencadc-metadata-curation` following repository transfer.

**Note:** Docker image references are not changed in this PR.